### PR TITLE
Implemented Circular Board

### DIFF
--- a/repository/IngSoft2-Model/DiceCup.class.st
+++ b/repository/IngSoft2-Model/DiceCup.class.st
@@ -14,15 +14,15 @@ DiceCup class >> with: die [
 ]
 
 { #category : #'instance creation' }
-DiceCup class >> withAll: dice [
-	
-	^self new initializeWithAll: dice.
+DiceCup class >> withAll: givenDice [
+
+	^ self new initializeWithAll: givenDice
 ]
 
 { #category : #initialization }
-DiceCup >> initializeWithAll: diceVar [
+DiceCup >> initializeWithAll: givenDice [
 
-	dice := diceVar.
+	dice := givenDice
 ]
 
 { #category : #rolling }

--- a/repository/IngSoft2-Model/Position.class.st
+++ b/repository/IngSoft2-Model/Position.class.st
@@ -3,22 +3,39 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'ship',
-		'square'
+		'square',
+		'lap'
 	],
 	#category : #'IngSoft2-Model'
 }
 
 { #category : #'instance creation' }
-Position class >> of: aSpaceship at: square [
+Position class >> of: aSpaceship at: square lap: lapNumber [
 
-	^ self new initializeOf: aSpaceship at: square
+	^ self new initializeOf: aSpaceship at: square lap: lapNumber.
+]
+
+{ #category : #comparing }
+Position >> = anotherPosition [
+
+	^ (self className = anotherPosition className) and: [ 
+		  lap = anotherPosition lap and: [ 
+			  ship = anotherPosition ship and: [ 
+				  square = anotherPosition square ] ] ]
 ]
 
 { #category : #initialization }
-Position >> initializeOf: aSpaceship at: aSquare [ 
-	
+Position >> initializeOf: aSpaceship at: aSquare lap: lapNumber [
+
 	ship := aSpaceship.
 	square := aSquare.
+	lap := lapNumber.
+]
+
+{ #category : #accessing }
+Position >> lap [
+
+	^lap.
 ]
 
 { #category : #accessing }

--- a/repository/IngSoft2-Model/PositionTracker.class.st
+++ b/repository/IngSoft2-Model/PositionTracker.class.st
@@ -2,76 +2,58 @@ Class {
 	#name : #PositionTracker,
 	#superclass : #Object,
 	#instVars : [
-		'records'
+		'positions'
 	],
 	#category : #'IngSoft2-Model'
 }
 
 { #category : #'instance creation' }
-PositionTracker class >> with: aSpaceship [ 
-	^self new initializeWithAll: { aSpaceship }.
+PositionTracker class >> with: aSpaceship [
+
+	^ self new initializeWithAll: { aSpaceship }.
 ]
 
 { #category : #'instance creation' }
 PositionTracker class >> withAll: spaceships [
 
-	^ self new initializeWithAll: spaceships
+	^ self new initializeWithAll: spaceships.
 ]
 
 { #category : #initialization }
 PositionTracker >> initializeWithAll: spaceships [
 
-	records := OrderedCollection withAll:
-		           (spaceships collect: [ :ship | 
-			            Position of: ship at: 1 ])
+	positions := OrderedCollection newFrom: (spaceships collect: [ :ship | Position of: ship at: 1 lap: 1 ]).
 ]
 
 { #category : #moving }
-PositionTracker >> move: aSpaceship forward: aNumberOfSquares [
+PositionTracker >> move: aSpaceship to: nextPosition lap: nextLap [
 
-	| shipRecord currentPosition nextPosition |
-	shipRecord := self
-		              positionOf: aSpaceship
-		              ifAbsent: [ 
-		              Error signal: 'Cannot move an unregistered ship' ].
-
-	currentPosition := shipRecord square.
-
-	nextPosition := currentPosition + aNumberOfSquares.
-
-	self move: aSpaceship to: nextPosition
-]
-
-{ #category : #moving }
-PositionTracker >> move: aSpaceship to: nextPosition [
+	self
+		positionOf: aSpaceship
+		ifAbsent: [ Error signal: 'Cannot move an unregistered ship' ].
 
 	self removePositionOf: aSpaceship.
-	
-	records add: (Position of: aSpaceship at: nextPosition).
-	
-	
+
+	positions add:
+		(Position of: aSpaceship at: nextPosition lap: nextLap)
 ]
 
 { #category : #accessing }
-PositionTracker >> positionOf: aSpaceship ifAbsent: aFullBlockClosure [ 
-	|matchingResults|
-	
-	matchingResults := records select: [ :record |
-		record ship = aSpaceship.
-	].
+PositionTracker >> positionOf: aSpaceship ifAbsent: aFullBlockClosure [
 
-	(matchingResults isEmpty) ifTrue: [ aFullBlockClosure value. ] ifFalse: [ ^matchingResults at: 1 ].
+	| matchingResults |
+	matchingResults := positions select: [ :position | 
+		                   (position ship) = aSpaceship ].
+
+	matchingResults isEmpty
+		ifTrue: [ aFullBlockClosure value ]
+		ifFalse: [ ^ matchingResults at: 1 ]
 ]
 
 { #category : #accessing }
 PositionTracker >> positions [
 
-	|spaceships  squares|
-	spaceships := self spaceships .
-
-	squares := records collect: [ :record | record square ].
-
-	^ Dictionary newFromKeys: spaceships andValues: squares
+	^ positions.
 ]
 
 { #category : #private }
@@ -79,13 +61,13 @@ PositionTracker >> removePositionOf: aSpaceship [
 	|foundRecord|
 	foundRecord := self positionOf: aSpaceship  ifAbsent: [ Error signal: 'Cannot delete record of unknown ship'. ].
 	
-	records remove: foundRecord ifAbsent: [].
+	positions remove: foundRecord ifAbsent: [].
 ]
 
 { #category : #accessing }
 PositionTracker >> spaceships [
 	
-	^ records collect: [ :record | 
-		record ship.
+	^ positions collect: [ :position | 
+		position ship.
 	]
 ]

--- a/repository/IngSoft2-Model/TrenchRunGameInstance.class.st
+++ b/repository/IngSoft2-Model/TrenchRunGameInstance.class.st
@@ -6,20 +6,28 @@ Class {
 		'gameBoard',
 		'state',
 		'positionTracker',
-		'sequence'
+		'sequence',
+		'endingLap'
 	],
 	#category : #'IngSoft2-Model'
 }
 
 { #category : #'instance creation' }
-TrenchRunGameInstance class >> withParticipating: spaceships rolling: aDiceCup on: aBoard [ 
-	^ self new initializeWithParticipating: spaceships rolling: aDiceCup on: aBoard. 
+TrenchRunGameInstance class >> withParticipating: spaceships rolling: aDiceCup on: aBoard endLap: lapNumber [
+
+	^ self new
+		  initializeWithParticipating: spaceships
+		  rolling: aDiceCup
+		  on: aBoard
+		  endLap: lapNumber.
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - positions' }
 TrenchRunGameInstance >> currentLeader [
 
-	^ (self positions keyAtValue: (self positions values detectMax: [ :square | square ] )) 
+	^ (self positions detectMax:
+		  [ :position | position lap * gameBoard length + position square ])
+			  ship
 ]
 
 { #category : #private }
@@ -28,13 +36,14 @@ TrenchRunGameInstance >> end [
 ]
 
 { #category : #initialization }
-TrenchRunGameInstance >> initializeWithParticipating: spaceships rolling: aDiceCup on: aBoard [
+TrenchRunGameInstance >> initializeWithParticipating: spaceships rolling: aDiceCup on: aBoard endLap: lapNumber [
 
 	gameBoard := aBoard.
 	dice := aDiceCup.
 	state := Started new.
+	endingLap := lapNumber.
 	positionTracker := PositionTracker withAll: spaceships.
-	sequence := TrenchRunSpaceshipSequence withAll: spaceships.
+	sequence := TrenchRunSpaceshipSequence withAll: spaceships
 ]
 
 { #category : #'asserting state' }
@@ -48,37 +57,69 @@ TrenchRunGameInstance >> isStarted [
 	^ state isStarted.
 ]
 
+{ #category : #'accessing - positions' }
+TrenchRunGameInstance >> lapOf: aShip [
+
+	^ (self positionOf: aShip) lap
+]
+
 { #category : #'turn related' }
 TrenchRunGameInstance >> playNextTurn [
 
-	| diceRollResult currentPosition nextPosition ship |
+	| diceRollResult currentSquare nextSquare ship currentLap nextLap |
 	ship := sequence nextInSequence.
-
-	currentPosition := (positionTracker positionOf: ship ifAbsent: [  ])
-		                   square.
-
-
+	currentSquare := self squareOf: ship.
+	currentLap := self lapOf: ship.
 	state update: self.
-
 	diceRollResult := dice roll.
+	nextSquare := currentSquare + diceRollResult \\ gameBoard length.
+	nextLap := currentLap
+	           +
+	           (currentSquare + diceRollResult - nextSquare
+	            / gameBoard length).
 
-	diceRollResult + currentPosition > gameBoard length
+	nextLap > endingLap
 		ifTrue: [ 
-			nextPosition := gameBoard length.
-			positionTracker move: ship to: nextPosition.
+			positionTracker move: ship to: 1 lap: endingLap + 1.
 			self end ]
-		ifFalse: [ 
-			nextPosition := diceRollResult + currentPosition.
-			positionTracker move: ship to: nextPosition ]
+		ifFalse: [ positionTracker move: ship to: nextSquare lap: nextLap ]
 ]
 
-{ #category : #accessing }
+{ #category : #private }
+TrenchRunGameInstance >> positionOf: aShip [
+
+	^ positionTracker positionOf: aShip ifAbsent: [  ]
+]
+
+{ #category : #'accessing - positions' }
 TrenchRunGameInstance >> positions [ 
 
 	^positionTracker positions.
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - positions' }
+TrenchRunGameInstance >> ranking [
+
+	| sortedPositions rankingSize |
+	sortedPositions := SortedCollection sortUsing: [ :firstPosition :secondPosition | 
+		                   firstPosition lap * gameBoard length + firstPosition square >
+		                   (secondPosition lap * gameBoard length + secondPosition square) ].
+	sortedPositions addAll: self positions.
+	rankingSize := 3 min: sortedPositions size.
+	
+	^ Dictionary newFromKeys: (1 to: rankingSize by: 1) andValues: (sortedPositions
+			collect: [ :position | position ship name ]
+			from: 1
+			to: rankingSize ).
+]
+
+{ #category : #'accessing - positions' }
+TrenchRunGameInstance >> squareOf: aShip [
+
+	^ (self positionOf: aShip) square
+]
+
+{ #category : #'accessing - positions' }
 TrenchRunGameInstance >> winner [
   ^state winner: self.
 ]

--- a/repository/IngSoft2-Tests/GameInstanceTest.class.st
+++ b/repository/IngSoft2-Tests/GameInstanceTest.class.st
@@ -20,26 +20,34 @@ GameInstanceTest >> testAskingForGameStateWhenFinishedReturnsFinished [
 	| game aShip aDiceCup aBoard |
 	aShip := Spaceship named: 'Enterprise'.
 	aBoard := Board sized: 5.
-	aDiceCup := DiceCup with: (LoadedDie with: 10).
+	aDiceCup := DiceCup with: (LoadedDie with: 6).
 	game := TrenchRunGameInstance
 		        withParticipating: { aShip }
 		        rolling: aDiceCup
-		        on: aBoard.
-	game playNextTurn .
+		        on: aBoard
+		        endLap: 1.
+
+	game playNextTurn.
 
 	self assert: [ game isFinished ]
 ]
 
 { #category : #tests }
 GameInstanceTest >> testAskingForGameStateWhenStartedReturnsStarted [
-	|game aShip aDiceCup aBoard|
+
+	| game aShip aDiceCup aBoard |
 	aShip := Spaceship new.
 	aBoard := Board sized: 10.
-	aDiceCup := DiceCup with:(LoadedDie with: 7).
-	game := TrenchRunGameInstance withParticipating: {aShip} rolling: aDiceCup on: aBoard.
-	game playNextTurn .
-	
-	self assert: [game isStarted].
+	aDiceCup := DiceCup with: (LoadedDie with: 7).
+	game := TrenchRunGameInstance
+		        withParticipating: { aShip }
+		        rolling: aDiceCup
+		        on: aBoard
+		        endLap: 1.
+		
+	game playNextTurn.
+
+	self assert: [ game isStarted ]
 ]
 
 { #category : #tests }
@@ -49,7 +57,7 @@ GameInstanceTest >> testAskingForWinnerWhenGameStillHasNotFinishedIsInvalid [
 	board := Board sized: 10.
 	aSpaceship := Spaceship named: 'Enterprise'.
 	die := LoadedDie with: 7.
-	game := TrenchRunGameInstance withParticipating: {aSpaceship} rolling: die on: board.
+	game := TrenchRunGameInstance withParticipating: {aSpaceship} rolling: die on: board endLap: 1.
 	
 	
 	self 
@@ -67,20 +75,19 @@ GameInstanceTest >> testMultipleShipsPositionsOnceGameIsFinished [
 	aSpaceshipNamedHernan := Spaceship named: 'Hernan'.
 	aLoadedDie := LoadedDie with: 8.
 	aBoard := Board sized: 10.
-
 	aGame := TrenchRunGameInstance
 		         withParticipating: { 
 				         aSpaceshipNamedJorge.
 				         aSpaceshipNamedJulian.
 				         aSpaceshipNamedHernan }
 		         rolling: aLoadedDie
-		         on: aBoard.
+		         on: aBoard
+		         endLap: 1.
 
 	aGame playNextTurn.
 	aGame playNextTurn.
 	aGame playNextTurn.
 	aGame playNextTurn.
-
 	winner := aGame winner.
 
 	self assert: [ aGame isFinished and: (winner name match: 'Jorge') ]
@@ -96,10 +103,10 @@ GameInstanceTest >> testOneShippedGameCanOnlyKnowWinnerOnceGameIsFinished [
 	aGame := TrenchRunGameInstance
 		         withParticipating: { aShip }
 		         rolling: aLoadedDie
-		         on: aBoard.
+		         on: aBoard
+		         endLap: 1.
 
 	aGame playNextTurn.
-
 	winner := aGame winner.
 
 	self assert:
@@ -121,7 +128,8 @@ GameInstanceTest >> testShipCannotStartAnotherTurnOnceGameHasFinished [
 				         aSpaceshipNamedJulian.
 				         aSpaceshipNamedHernan }
 		         rolling: aLoadedDie
-		         on: aBoard.
+		         on: aBoard
+					endLap: 1.
 
 	aGame playNextTurn.
 
@@ -132,6 +140,25 @@ GameInstanceTest >> testShipCannotStartAnotherTurnOnceGameHasFinished [
 ]
 
 { #category : #tests }
+GameInstanceTest >> testSpaceshipCompletingALapActuallyCountsIntoPositionTracker [
+
+	| game aShip aDiceCup aBoard |
+	aShip := Spaceship named: 'Enterprise'.
+	aBoard := Board sized: 5.
+	aDiceCup := DiceCup with: (LoadedDie with: 8).
+	game := TrenchRunGameInstance
+		        withParticipating: { aShip }
+		        rolling: aDiceCup
+		        on: aBoard
+		        endLap: 2.
+
+	game playNextTurn.
+
+	self assert:
+		((game lapOf: aShip) = 2 and: [ (game squareOf: aShip) = 4 ])
+]
+
+{ #category : #tests }
 GameInstanceTest >> testStartedGamePlaysUntilOneSpaceshipWins [
 
 	| aSpaceshipNamedJorge aSpaceshipNamedJulian aBoard aLoadedDie aGame |
@@ -139,71 +166,83 @@ GameInstanceTest >> testStartedGamePlaysUntilOneSpaceshipWins [
 	aSpaceshipNamedJulian := Spaceship named: 'Julian'.
 	aLoadedDie := LoadedDie with: 4.
 	aBoard := Board sized: 10.
-
 	aGame := TrenchRunGameInstance
 		         withParticipating: { 
 				         aSpaceshipNamedJorge.
 				         aSpaceshipNamedJulian }
 		         rolling: aLoadedDie
-		         on: aBoard.
+		         on: aBoard
+		         endLap: 1.
 
 	[ aGame isFinished ] whileFalse: [ 
-		aGame playNextTurn .
-		aGame isFinished ifFalse: [ aGame playNextTurn.] ].
-	self assert:
-		(aGame isFinished and: [ aGame winner name match: 'Jorge' ])
+		aGame playNextTurn.
+		aGame isFinished ifFalse: [ aGame playNextTurn ] ].
+
+	self assert: (aGame isFinished and: [ aGame winner name match: 'Jorge' ])
 ]
 
 { #category : #'tests - starting game checks' }
 GameInstanceTest >> testStartingGameWithOneSpaceshipIsValid [
-	|game aShip aDiceCup aBoard|
+
+	| game aShip aDiceCup aBoard |
 	aShip := Spaceship new.
 	aBoard := Board sized: 10.
-	aDiceCup := DiceCup with:(LoadedDie with: 7).
-	
-	"When only one spaceship is being added to game, message withShip:diceCup:board: can be used"
-	game := TrenchRunGameInstance withParticipating: {aShip} rolling: aDiceCup on: aBoard.
+	aDiceCup := DiceCup with: (LoadedDie with: 7).
+	game := TrenchRunGameInstance
+		        withParticipating: { aShip }
+		        rolling: aDiceCup
+		        on: aBoard
+		        endLap: 1.
+		
 	game playNextTurn.
-	
-	self assert: (game isStarted).
+
+	self assert: game isStarted
 ]
 
 { #category : #tests }
 GameInstanceTest >> testStartingGameWithTwoOrMoreSpaceshipsIsValid [
-	|game aFirstShip aSecondShip aDiceCup aBoard|
+
+	| game aFirstShip aSecondShip aDiceCup aBoard |
 	aFirstShip := Spaceship named: 'Planet Express'.
 	aSecondShip := Spaceship named: 'Enterprise'.
-	
+	aDiceCup := DiceCup with: (LoadedDie with: 5).
 	aBoard := Board sized: 10.
-	aDiceCup := DiceCup with:(LoadedDie with: 5).
-	
-	"When two or more spaceships want to be added to a game, message withSpaceships:diceCup:board: must be used"
-	game := TrenchRunGameInstance withParticipating: {aFirstShip . aSecondShip } rolling: aDiceCup on: aBoard.
+	game := TrenchRunGameInstance
+		        withParticipating: { 
+				        aFirstShip.
+				        aSecondShip }
+		        rolling: aDiceCup
+		        on: aBoard
+		        endLap: 1.
+
 	game playNextTurn.
 	game playNextTurn.
-	
-	self assert: [game isStarted].
+
+	self assert: [ game isStarted ]
 ]
 
 { #category : #tests }
 GameInstanceTest >> testTwoShippedGameCanOnlyKnowWinnerOnceGameIsFinished [
-	|aSpaceshipNamedJorge aSpaceshipNamedJulian aBoard aLoadedDie aGame winner|
+
+	| aSpaceshipNamedJorge aSpaceshipNamedJulian aLoadedDie aGame aBoard winner |
 	aSpaceshipNamedJorge := Spaceship named: 'Jorge'.
 	aSpaceshipNamedJulian := Spaceship named: 'Julian'.
-	aLoadedDie := LoadedDie with: 6.
 	aBoard := Board sized: 10.
-
-	aGame := TrenchRunGameInstance withParticipating: {aSpaceshipNamedJorge. aSpaceshipNamedJulian} rolling: aLoadedDie on: aBoard.
+	aLoadedDie := LoadedDie with: 6.
+	aGame := TrenchRunGameInstance
+		         withParticipating: { 
+				         aSpaceshipNamedJorge.
+				         aSpaceshipNamedJulian }
+		         rolling: aLoadedDie
+		         on: aBoard 
+		         endLap: 1.
 
 	aGame playNextTurn.
-
 	aGame playNextTurn.
 	aGame playNextTurn.
-
-
 	winner := aGame winner.
-	
-	self assert: ((aGame isFinished and: (winner name match: 'Jorge'))).
+
+	self assert: (aGame isFinished and: (winner name match: 'Jorge'))
 ]
 
 { #category : #tests }
@@ -214,13 +253,13 @@ GameInstanceTest >> testWinnerOfFixedMatchMatchesPositionsTable [
 	aSpaceshipNamedJulian := Spaceship named: 'Julian'.
 	aLoadedDie := LoadedDie with: 6.
 	aBoard := Board sized: 10.
-
 	aGame := TrenchRunGameInstance
 		         withParticipating: { 
 				         aSpaceshipNamedJorge.
 				         aSpaceshipNamedJulian }
 		         rolling: aLoadedDie
-		         on: aBoard.
+		         on: aBoard
+		         endLap: 1.
 
 	aGame playNextTurn.
 	aGame playNextTurn.
@@ -230,5 +269,32 @@ GameInstanceTest >> testWinnerOfFixedMatchMatchesPositionsTable [
 
 	self assert: (aGame isFinished and: [ 
 			 (aGame winner name match: 'Jorge') and: [ 
-				 (positions at: aSpaceshipNamedJorge) = aBoard length ] ])
+				 (aGame squareOf: aSpaceshipNamedJorge) = 1 and: [ 
+					 (aGame lapOf: aSpaceshipNamedJorge) = 2 ] ] ])
+]
+
+{ #category : #tests }
+GameInstanceTest >> testWinnerOfFixedMatchMatchesRanking [
+
+	| aSpaceshipNamedJorge aSpaceshipNamedJulian aBoard aLoadedDie aGame positions |
+	aSpaceshipNamedJorge := Spaceship named: 'Jorge'.
+	aSpaceshipNamedJulian := Spaceship named: 'Julian'.
+	aLoadedDie := LoadedDie with: 6.
+	aBoard := Board sized: 10.
+	aGame := TrenchRunGameInstance
+		         withParticipating: { 
+				         aSpaceshipNamedJorge.
+				         aSpaceshipNamedJulian }
+		         rolling: aLoadedDie
+		         on: aBoard
+		         endLap: 1.
+
+	aGame playNextTurn.
+	aGame playNextTurn.
+	aGame playNextTurn.
+
+	positions := aGame positions.
+
+	self assert: (aGame isFinished and: [ 
+			 (aGame winner name match: 'Jorge') and: [ (aGame ranking at: 1) match: 'Jorge' ]]).
 ]

--- a/repository/IngSoft2-Tests/PositionTrackerTest.class.st
+++ b/repository/IngSoft2-Tests/PositionTrackerTest.class.st
@@ -15,11 +15,20 @@ PositionTrackerTest >> should: aBlock raise: anErrorType withMessage: anErrorMes
 ]
 
 { #category : #'tests - LeaderboardRecord' }
+PositionTrackerTest >> testAskingForLapOnRecordReturnsLap [
+
+	|aShip record|
+	aShip := Spaceship named: 'Enterprise'.
+	record := Position of: aShip at: 4 lap: 1.
+	self assert: record lap equals: 1.
+]
+
+{ #category : #'tests - LeaderboardRecord' }
 PositionTrackerTest >> testAskingForShipOnRecordReturnsSameShip [
 
 	|aShip record|
 	aShip := Spaceship named: 'Enterprise'.
-	record := Position of: aShip at: 4.
+	record := Position of: aShip at: 4 lap: 1.
 	self assert: record ship equals: aShip.
 ]
 
@@ -28,33 +37,8 @@ PositionTrackerTest >> testAskingForSquareOnRecordReturnsSquare [
 
 	|aShip record|
 	aShip := Spaceship named: 'Enterprise'.
-	record := Position of: aShip at: 4.
+	record := Position of: aShip at: 4 lap: 1.
 	self assert: record square equals: 4.
-]
-
-{ #category : #'tests - LeaderboardRecord' }
-PositionTrackerTest >> testCreatingALeaderboardRecordWithAPositivePositionAndShipIsValid [
-
-	|record aShip|
-	aShip := Spaceship named: 'Enterprise'.
-	record := Position of: aShip at: 4.
-]
-
-{ #category : #'tests - Leaderboard' }
-PositionTrackerTest >> testCreatingALeaderboardWithASingleShipIsValid [
-
-	|leaderboard aShip|
-	aShip := Spaceship named: 'Enterprise'.
-	leaderboard := PositionTracker with: aShip.
-]
-
-{ #category : #'tests - Leaderboard' }
-PositionTrackerTest >> testCreatingALeaderboardWithMultipleShipsIsValid [
-
-	|leaderboard aFirstShip aSecondShip|
-	aFirstShip := Spaceship named: 'Enterprise'.
-	aSecondShip := Spaceship named: 'PlanetExpress'.
-	leaderboard := PositionTracker withAll: {aFirstShip. aSecondShip}.
 ]
 
 { #category : #'tests - Leaderboard' }
@@ -80,13 +64,17 @@ PositionTrackerTest >> testMovingAShipForwardSquaresUpdatesRankings [
 
 	self
 		assert: leaderboard positions
-		equals: (Dictionary newFromKeys: { aSpaceship } andValues: { 1 }).
+		equals:
+		(OrderedCollection newFrom:
+			 { (Position of: aSpaceship at: 1 lap: 1) }).
 
-	leaderboard move: aSpaceship forward: 5.
+	leaderboard move: aSpaceship to: 6 lap: 1.
 
 	self
 		assert: leaderboard positions
-		equals: (Dictionary newFromKeys: { aSpaceship } andValues: { 6 })
+		equals:
+		(OrderedCollection newFrom:
+			 { (Position of: aSpaceship at: 6 lap: 1) })
 ]
 
 { #category : #'tests - Leaderboard' }
@@ -98,29 +86,43 @@ PositionTrackerTest >> testMovingAnUnknownShipForwardSquaresIsInvalid [
 	leaderboard := PositionTracker with: aSpaceship.
 
 	self
-		should: [ leaderboard move: anotherSpaceship forward: 5]
+		should: [ leaderboard move: anotherSpaceship to: 5 lap: 1 ]
 		raise: Error
 		withMessage: 'Cannot move an unregistered ship'
 ]
 
 { #category : #'tests - Leaderboard' }
-PositionTrackerTest >> testObtainingAllSpaceshipsFromTheLeaderboardReturnsCollectionWithShips [
+PositionTrackerTest >> testObtainingAllSpaceshipsFromPositionTrackerReturnsCollectionWithShips [
 
-	|aFirstShip aSecondShip leaderboard|
+	| aFirstShip aSecondShip leaderboard |
 	aFirstShip := Spaceship named: 'Enterprise'.
 	aSecondShip := Spaceship named: 'PlanetExpress'.
-	leaderboard := PositionTracker withAll: { aFirstShip . aSecondShip }.
-	
-	self assert: (leaderboard spaceships) equals: (OrderedCollection withAll: { aFirstShip . aSecondShip }).
+	leaderboard := PositionTracker withAll: { 
+			               aFirstShip.
+			               aSecondShip }.
+
+	self
+		assert: leaderboard spaceships
+		equals: (OrderedCollection withAll: { 
+					 aFirstShip.
+					 aSecondShip })
 ]
 
 { #category : #'tests - Leaderboard' }
-PositionTrackerTest >> testObtainingRankingsFromLeaderboardReturnsDictionaryWithNamesOfShipsAndTheirPositions [
+PositionTrackerTest >> testObtainingPositionsFromLeaderboardReturnsDictionaryWithNamesOfShipsAndTheirPositions [
 
-	|aFirstShip aSecondShip leaderboard|
+	| aFirstShip aSecondShip leaderboard |
 	aFirstShip := Spaceship named: 'Enterprise'.
 	aSecondShip := Spaceship named: 'PlanetExpress'.
-	leaderboard := PositionTracker withAll: { aFirstShip . aSecondShip }.
-	
-	self assert: (leaderboard positions) equals: (Dictionary newFromKeys: { aFirstShip . aSecondShip } andValues: { 1 . 1 }).
+	leaderboard := PositionTracker withAll: { 
+			               aFirstShip.
+			               aSecondShip }.
+
+	self
+		assert: (leaderboard positions at: 1)
+		equals: (Position of: aFirstShip at: 1 lap: 1).
+
+	self
+		assert: (leaderboard positions at: 2)
+		equals: (Position of: aSecondShip at: 1 lap: 1)
 ]


### PR DESCRIPTION
- Added methods to obtain lap and square in a more declarative way
- Added ranking that returns the three leading ships in a game. Can be called in a running or finished game
- removed move:forward: to keep things simple

closes #21